### PR TITLE
Make the sed command compatible with BSD sed

### DIFF
--- a/tmux-repl.lua
+++ b/tmux-repl.lua
@@ -37,7 +37,7 @@ end)
 -- Sends the selected text to the REPL target pane. (use in visual mode)
 vis:command_register("repl-send", function(argv, _, win)
     if win.repl_target_pane then
-        vis:command('> sed \'s/;$/\\\\\\;/g; s/.*/\\0\\\\nEnter/\' ' ..
+        vis:command('> sed \'s/;$/\\\\\\;/g; s/\\(.*\\)/\\1\\\\nEnter/\' ' ..
                     '  | tr "\\\\n" "\\0" ' ..
                     '  | xargs -0 tmux send-keys -t ' .. win.repl_target_pane)
     end


### PR DESCRIPTION
`\0` for the whole match does not seem to work for `sed` on Macs (which is of BSD origin I believe).
The `sed` code is modified to use grouping and `\1` instead.